### PR TITLE
Add allegations.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 db_config.py
+venv/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 ## Setup
 
+### Install dependencies
+For Mac or Linux systems, all you should need is Python3.
+Then, you can run the following:
+
+```bash
+python3 -m venv venv
+. venv/bin/activate
+pip3 install -r requirements.txt
+```
+
+You can call your virtual environment something else,
+but the `./venv/` directory is already gitignored for this repo.
+
 ### Set up the DB
 
 1. Set up a local MySQL database (actual setup will depend on your OS).

--- a/README.md
+++ b/README.md
@@ -18,10 +18,19 @@
 
 ### Clean CSV files and insert them into the `cases` table
 
-Running ingest.py will clean CSV files and insert the data into the cases table. You can run ingest.py in three ways:
+Running `ingest.py` will clean CSV files and insert the data into the cases table. You can run ingest.py in three ways:
 
 - running `ingest.py` with no arguments will clean and load all lines of all CSV files in the `case_files` directory
 - running `ingest.py some_file.csv` will clean and load all lines of `some_file.csv`
 - running `ingest.py some_file.csv 50` will clean and load the first 50 lines of `some_file.csv`
 
 **Note:** `ingest.py` appends rows to the `cases` table if there are more than zero rows in the table, so if you want to start from an empty table, you will need to truncate the `cases` table before re-running `ingest.py`.
+
+### Process allegations
+
+Running `./allegations.py` will:
+
+* Read each case's `allegations_raw`, when not null or empty
+* Attempt to parse any allegations within the text
+* Populate the `allegations` table for each allegation found
+* Set the case's `allegations_parse_error` to `YES`/`1` if one or more allegations failed to parse.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,16 @@
 ### Set up the DB
 
 1. Set up a local MySQL database (actual setup will depend on your OS).
-2. Start mysql and create the `nlrb_data` database:
+1. Start mysql and create the `nlrb_data` database:
 `mysql> create database nlrb_data;`
-3. Create the `nlrb_data.cases` table:
-`mysql> source /path/to/nlrb_data/sql/cases.sql`
-4. Rename `db_config-example.py` to `db_config.py` and add your DB username, host, and password.
+1. Set up a user:
+    * `mysql> CREATE USER IF NOT EXISTS nlrb IDENTIFIED BY 'whateveryourpasswordis';` (change the password)
+    * `mysql> GRANT ALL ON nlrb_data.* TO 'nlrb'@'localhost';`
+    * `mysql> FLUSH PRIVILEGES;`
+1. Create tables, assuming you start MySQL from the top level of the git repo:
+    * `mysql> source sql/cases.sql` (or `mysql -u nlrb -p nlrb_data < sql/cases.sql` from your shell)
+    * `mysql> source sql/allegations.sql`
+1. Rename `db_config-example.py` to `db_config.py` and add your DB username, host, and password.
 
 ### Clean CSV files and insert them into the `cases` table
 

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Running `./allegations.py` will:
 * Attempt to parse any allegations within the text
 * Populate the `allegations` table for each allegation found
 * Set the case's `allegations_parse_error` to `YES`/`1` if one or more allegations failed to parse.
+
+## Fixing stuff
+If you find yourself in a pickle while developing, you can always run `./reset.sh` to reload your data set.
+(Currently just the Tesla data.)
+
+This won't help if you changed the SQL files, though.
+You'll have to drop those tables and resource the schema files.

--- a/allegations.py
+++ b/allegations.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import re
+
+import pymysql
+
+# Match cases like 8(a)(1) and 8(a)(1)(A)
+# '(?:\([A-Z]+\))?' is an optional non-matching group for the last (A)
+# Could also just do something like this:
+# '(\d(?:\([0-9a-zA-Z]+\))?) (.+)'
+pat = '(\d\([a-z]+\)\(\d+\)(?:\([A-Z]+\))?) (.+)'
+pat = re.compile(pat)
+
+def _parse_allegations(s: str) -> (str, str):
+    lines = (x.strip() for x in s.strip().split('\n'))
+    # Ignore empty lines in case of "\n \n" or "\n\n"
+    lines = (l for l in lines if l != "")
+    matches = ((pat.match(line), line) for line in lines)
+    return [
+            (m.group(1), m.group(2), None) if m is not None
+            else (None, None, line)
+            for m,line in matches
+            ]
+
+
+def process_allegations(cursor, case_row):
+    raw = case_row['allegations_raw']
+    case_id = case_row['id']
+
+    exc = None
+    try:
+        okay = True
+        for result in _parse_allegations(raw):
+            code, desc, err = result
+            if err is not None:
+                print(f'\tERROR CASE({case_row["case_number"]}): {err}')
+                okay = False
+                continue
+            # Could executemany() here, but then we wouldn't be able to skip on err
+            cursor.execute('INSERT INTO allegations (case_id, code, description) VALUES (%s, %s, %s);', (case_id, code, desc))
+
+        # We could also check `if okay:` and mark a *successful* run,
+        # but we'd have to update the data model a bit first.
+        if not okay:
+            # Mark case allegations with bad parse
+            #TODO How do I ensure this worked?
+            cursor.execute('UPDATE cases SET allegations_parse_error = 1 WHERE id = %s;', (case_id))
+
+    except Exception as e:
+        print(f'Error: {e}')
+        exc = e
+    finally:
+        cursor.close()
+        if exc is not None:
+            raise(exc)
+
+
+def test_regex():
+    regex_tests = [
+            {
+                'description': 'Valid 3-term allegation',
+                'case': '8(a)(3) Discharge (Including Layoff and Refusal to Hire (not salting))',
+                'expected': ('8(a)(3)', 'Discharge (Including Layoff and Refusal to Hire (not salting))')
+            },
+            {
+                'description': 'Valid 4-term allegation',
+                'case': "8(b)(1)(A) Duty of Fair Representation, incl'g Superseniority, denial of access",
+                'expected': ("8(b)(1)(A)", "Duty of Fair Representation, incl'g Superseniority, denial of access")
+            },
+            {
+                'description': 'Invalid allegation (numeric second term)',
+                'case': "8(8)(1)(A) Duty of Fair Representation, incl'g Superseniority, denial of access",
+                'expected': None
+            },
+            {
+                'description': 'Valid hypothetical third term greater than 9',
+                'case': '8(b)(11)(A) Something I made up',
+                'expected': ('8(b)(11)(A)', 'Something I made up')
+            }
+            ]
+    for t in regex_tests:
+        print('Testing:', t['description'])
+        got = pat.match(t['case'])
+        expected = t['expected']
+        if expected is None and got is not None:
+            print(f'Expected None, got {got.group(1)} and {group(2)}')
+            return False
+        if expected is not None and got is None:
+            print(f'Expected {expected[0]}, {expected[1]}, got None')
+            return False
+        if expected is None and got is None:
+            continue
+
+        gots = got.group(1), got.group(2)
+        if gots != expected:
+            print(f'Expected\n{expected}\nGot\n{gots}')
+            return False
+
+    # Tests passed
+    return True
+
+def test_parse_allegations():
+    tests = [
+            {
+                'description': 'Multiple valid allegations',
+                'case': """8(a)(3) Discharge (Including Layoff and Refusal to Hire (not salting))
+                8(a)(1) Concerted Activities (Retaliation, Discharge, Discipline)
+                8(a)(1) Coercive Statements (Threats, Promises of Benefits, etc.)
+                """,
+                'expected': [
+                    ('8(a)(3)', 'Discharge (Including Layoff and Refusal to Hire (not salting))', None),
+                    ('8(a)(1)', 'Concerted Activities (Retaliation, Discharge, Discipline)', None),
+                    ('8(a)(1)', 'Coercive Statements (Threats, Promises of Benefits, etc.)', None)
+                    ]
+            },
+            {
+                'description': 'Test single line and trailing whitespace',
+                'case': """8(a)(1) Concerted Activities (Retaliation, Discharge, Discipline)
+                """,
+                'expected': [
+                    ('8(a)(1)', 'Concerted Activities (Retaliation, Discharge, Discipline)', None)
+                    ]
+            },
+            {
+                'description': 'Empty lines are ignored',
+                'case': """8(a)(1) Coercive Rules
+
+                8(a)(1) Concerted Activities (Retaliation, Discharge, Discipline)
+                """,
+                'expected': [
+                    ('8(a)(1)', 'Coercive Rules', None),
+                    ('8(a)(1)', 'Concerted Activities (Retaliation, Discharge, Discipline)', None)
+                    ]
+            },
+            {
+                'description': 'Mismatch fails gracefully',
+                'case': """8(2)(1) Coercive Rules
+                8(a)(1) Concerted Activities (Retaliation, Discharge, Discipline)
+                """,
+                'expected': [
+                    (None, None, '8(2)(1) Coercive Rules'),
+                    ('8(a)(1)', 'Concerted Activities (Retaliation, Discharge, Discipline)', None)
+                    ]
+            }
+        ]
+
+    for t in tests:
+        print('Testing:', t['description'])
+        got = _parse_allegations(t['case'])
+        expected = t['expected']
+        if got != expected:
+            print(f'Expected\n{expected}\nGot\n{got}')
+            return False
+
+    # Tests passed
+    return True
+
+
+if __name__ == '__main__':
+    if not test_regex() or not test_parse_allegations():
+        import sys
+        sys.exit(1)
+
+    print('Tests passed, beginning migration.')
+
+    from connection import Connection
+    import db_config
+
+    allegations_query = """
+    SELECT id, case_number, allegations_raw
+    FROM cases
+    WHERE allegations_raw IS NOT NULL AND allegations_raw<>''
+    ;
+    """
+
+    cnx = Connection(db_config)
+    cnx.begin()
+    try:
+        c = cnx.cursor()
+        n = c.execute(allegations_query)
+        print(f'Cases with allegations: {n}')
+        for row in c:
+            process_allegations(cnx.cursor(), row)
+        cnx.commit()
+        print('Migration complete.')
+    except Exception as e:
+        print(f'Error: {e}')
+        print('Rolling back.')
+        cnx.rollback()
+    finally:
+        c.close()
+        cnx.close()

--- a/allegations.py
+++ b/allegations.py
@@ -41,9 +41,12 @@ def process_allegations(cursor, case_row):
 
         # We could also check `if okay:` and mark a *successful* run,
         # but we'd have to update the data model a bit first.
-        if not okay:
-            # Mark case allegations with bad parse
+        if okay:
+            # Mark case with successful allegations parse
             #TODO How do I ensure this worked?
+            cursor.execute('UPDATE cases SET allegations_parse_error = 0 WHERE id = %s;', (case_id))
+        else:
+            # Mark case with failed allegations parse
             cursor.execute('UPDATE cases SET allegations_parse_error = 1 WHERE id = %s;', (case_id))
 
     except Exception as e:
@@ -63,7 +66,9 @@ def main():
     allegations_query = """
     SELECT id, case_number, allegations_raw
     FROM cases
-    WHERE allegations_raw IS NOT NULL AND allegations_raw<>''
+    WHERE allegations_raw IS NOT NULL
+    AND allegations_raw <> ''
+    AND allegations_parse_error IS NULL
     ;
     """
 

--- a/case_files/nlrb-tesla_cases.csv
+++ b/case_files/nlrb-tesla_cases.csv
@@ -333,4 +333,3 @@ Charged Party / Respondent, Legal Representative, Holland Ronald, SHEPPARD, MULL
 Charging Party, Union, INTERNATIONAL UNION, UNITED AUTOMOBILE, AEROSPACE AND AGRICULTURAL IMPLEMENT WORKERS OF AMERICA, AFL-CIO, REGION 5, Fremont, CA, 94538-6317
 Charged Party / Respondent, Employer, TESLA MOTORS, INC., Palo Alto, CA, 94304-1317
 ",,,
-,,,,,,,,,,,,,,,

--- a/connection.py
+++ b/connection.py
@@ -1,0 +1,21 @@
+"""
+Connection is just a wrapper around pymysql.Connection
+to provide preferable cursor defaults throughout the project.
+"""
+
+import pymysql
+
+class Connection(pymysql.Connection):
+    # We get __enter__() for free, just want it to call __init__
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(host=config.host,
+                       user=config.user,
+                       password=config.password,
+                       database=config.database,
+                       *args, **kwargs)
+
+    def cursor(self, cursor=pymysql.cursors.DictCursor, **kwargs):
+        """Ensure ANSI_QUOTES, default to DictCursor"""
+        c = super().cursor(cursor=cursor, **kwargs)
+        c.execute('SET SQL_MODE=ANSI_QUOTES')
+        return c

--- a/db_config-example.py
+++ b/db_config-example.py
@@ -1,4 +1,4 @@
-host = ''
-user = ''
-password = ''
+host = 'localhost'
+user = 'nlrb'
+password = 'badpassword'
 database = 'nlrb_data'

--- a/ingest.py
+++ b/ingest.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import db_config
 from os import listdir
 import pymysql

--- a/ingest.py
+++ b/ingest.py
@@ -36,9 +36,9 @@ def convert_closed_date(val, row):
 def clean_data(cases_tbl):
     clean_tbl = etl.addfield(cases_tbl, 'docket_activity_raw', None, 13)
     clean_tbl = etl.addfields(clean_tbl, [
-        ('allegations_parse_error', 0),
-        ('participants_parse_error', 0),
-        ('docket_activity_parse_error', 0)
+        ('allegations_parse_error', None),
+        ('participants_parse_error', None),
+        ('docket_activity_parse_error', None)
     ])
     clean_tbl = etl.convert(clean_tbl, 'date_filed',
                             convert_filed_date, pass_row=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+cffi==1.15.1
+cryptography==40.0.1
+petl==1.7.12
+pycparser==2.21
+PyMySQL==1.0.3
+PyNaCl==1.5.0

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+echo "Emptying tables"
+# Can't truncate cases due to foreign key from allegations
+mysql -u nlrb -p nlrb_data -Be 'TRUNCATE allegations; DELETE FROM cases;'
+
+echo "Reloading data"
+./ingest.py case_files/nlrb-tesla_cases.csv
+./allegations.py
+
+echo "Summarizing"
+mysql -u nlrb -p nlrb_data -Be 'SELECT COUNT(*) FROM cases; SELECT COUNT(*) FROM allegations;'

--- a/sql/allegations.sql
+++ b/sql/allegations.sql
@@ -1,0 +1,12 @@
+USE `nlrb_data`;
+DROP TABLE IF EXISTS `allegations`;
+CREATE TABLE `allegations` (
+    `id` INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    `case_id` INT NOT NULL,
+    `code` VARCHAR(16) NOT NULL,
+    `description` VARCHAR(256) NOT NULL,
+    CONSTRAINT `fk_allegation_case`
+      FOREIGN KEY (case_id) REFERENCES cases (id)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE=InnoDB CHARSET=utf8mb4;

--- a/sql/cases.sql
+++ b/sql/cases.sql
@@ -19,10 +19,7 @@ CREATE TABLE `cases` (
     `union_name` VARCHAR(512),
     `unit_sought` VARCHAR (512),
     `voters` INT,
-    `allegations_parsed` BOOLEAN NOT NULL DEFAULT FALSE,
-    `participants_parsed` BOOLEAN NOT NULL DEFAULT FALSE,
-    `docket_activity_parsed` BOOLEAN NOT NULL DEFAULT FALSE,
-    `allegations_parse_error` BOOLEAN NOT NULL DEFAULT TRUE,
-    `participants_parse_error` BOOLEAN NOT NULL DEFAULT TRUE,
-    `docket_activity_parse_error` BOOLEAN NOT NULL DEFAULT TRUE
+    `allegations_parse_error` BOOLEAN,
+    `participants_parse_error` BOOLEAN,
+    `docket_activity_parse_error` BOOLEAN
 ) ENGINE=InnoDB CHARSET=utf8mb4


### PR DESCRIPTION
I got allegations working with the current data set! Closes #3 .

I also tested that if I didn't support parsing that extra `(A)` in `8(b)(1)(A)`, the resulting `case` record would then have `allegations_parse_error` set to `1`/`YES`.

Other changes:

* Add a `Connection` subclass of `pymysql.Connection` in `connection.py` to set some handy defaults for new cursors. Not sure how well this plays with PETL, so I'm only using it in `allegations.py` for now.
* Added `requirements.txt` and gitignore'd `venv`
* Updated README with further instructions installation, SQL setup, and parsing allegations

There's plenty of room for improvement in `allegations.py`, so review would be much appreciated.

## Some results

```mysql
MariaDB [nlrb_data]> select code, count(code) from allegations group by code;
+------------+-------------+
| code       | count(code) |
+------------+-------------+
| 8(a)(1)    |          65 |
| 8(a)(3)    |          17 |
| 8(a)(4)    |           2 |
| 8(a)(5)    |           1 |
| 8(b)(1)(A) |           1 |
| 8(b)(3)    |           2 |
+------------+-------------+
6 rows in set (0.001 sec)
```

Regarding the question of, "Is an allegation's description consistent for a given code?" ...looks like NOPE. But it's possible that the descriptions are nonetheless limited?

```mysql
MariaDB [nlrb_data]> SELECT DISTINCT code, description FROM allegations ORDER BY code;
+------------+----------------------------------------------------------------------+
| code       | description                                                          |
+------------+----------------------------------------------------------------------+
| 8(a)(1)    | Coercive Actions (Surveillance, etc)                                 |
| 8(a)(1)    | Coercive Rules                                                       |
| 8(a)(1)    | Coercive Statements (Threats, Promises of Benefits, etc.)            |
| 8(a)(1)    | Concerted Activities (Retaliation, Discharge, Discipline)            |
| 8(a)(1)    | Denial of Access                                                     |
| 8(a)(1)    | Discharge of supervisor (Parker-Robb Chevrolet)                      |
| 8(a)(1)    | Interrogation (including Polling)                                    |
| 8(a)(3)    | Changes in Terms and Conditions of Employment                        |
| 8(a)(3)    | Discharge (Including Layoff and Refusal to Hire (not salting))       |
| 8(a)(3)    | Discipline                                                           |
| 8(a)(4)    | Changes in Terms and Conditions of Employment                        |
| 8(a)(4)    | Discharge (including Layoff and Refusal to Hire)                     |
| 8(a)(5)    | Repudiation/Modification of Contract [Sec 8(d)/Unilateral Changes]   |
| 8(b)(1)(A) | Duty of Fair Representation, incl'g Superseniority, denial of access |
| 8(b)(3)    | Refusal to Bargain/Bad Faith or Surface Bargaining                   |
| 8(b)(3)    | Repudiation/Modification of Contract                                 |
+------------+----------------------------------------------------------------------+
16 rows in set (0.001 sec)
```